### PR TITLE
Updated dataset folder path

### DIFF
--- a/load_data.py
+++ b/load_data.py
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--path",help="Path where omniglot folder resides")
 parser.add_argument("--save", help = "Path to pickle data to.", default=os.getcwd())
 args = parser.parse_args()
-data_path = os.path.join(args.path,"omniglot" ,"python")
+data_path = os.path.join(args.path, "python")
 train_folder = os.path.join(data_path,'images_background')
 valpath = os.path.join(data_path,'images_evaluation')
 


### PR DESCRIPTION
Following the README instructions, we should use the command `python load_data.py --path` on the omniglot dataset folder, therefore, it is unnecessary to append "omniglot" to the path. The inconsistency caused the data to not be loaded properly.